### PR TITLE
리팩토링 : 예외처리 방법 개선

### DIFF
--- a/server/src/main/java/backend/server/exception/BusinessException.java
+++ b/server/src/main/java/backend/server/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package backend.server.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/server/src/main/java/backend/server/exception/ErrorCode.java
+++ b/server/src/main/java/backend/server/exception/ErrorCode.java
@@ -1,0 +1,39 @@
+package backend.server.exception;
+
+public enum ErrorCode {
+
+    // Activity
+    ACTIVITY_ALREADY_IN_PROGRESS(400L, "이미 진행 중인 활동이 있습니다.", 400),
+    PARTNER_NOT_FOUND(404L, "파트너가 존재하지 않습니다.", 404),
+    MEMBER_NOT_FOUND(405L, "사용자가 존재하지 않습니다.", 404),
+    ACTIVITY_NOT_FOUND(404L, "활동이 존재하지 않습니다.", 404),
+    ACTIVITY_ALREADY_DONE(407L, "이미 종료된 활동입니다.", 400),
+    MINIMUM_ACTIVITY_TIME_NOT_SATISFY(500L, "최소 활동 시간을 초과하지 못했습니다.", 400),
+    MINIMUM_ACTIVITY_DISTANCE_NOT_SATISFY (501L,"최소 활동 거리를 초과하지 못했습니다.",400),
+    ACTIVITY_ABNORMAL_DONE_WITHOUT_MINIMUM_TIME(502L, "활동이 비정상적으로 종료되었고 시간을 충족시키지 못했습니다.", 400),
+    ACTIVITY_ABNORMAL_DONE_WITHOUT_MINIMUM_DISTANCE(503L,"활동이 비정상적으로 종료되었고 거리를 충족시키지 못했습니다.",400),
+    ACTIVITY_DONE_PHOTO_NOT_SEND(405L, "종료 사진이 전송되지 않았습니다.", 400),
+    ACTIVITY_MAP_PHOTO_NOT_SEND(406L, "맵 경로 사진이 전송되지 않았습니다.", 400);
+
+    private final Long code;
+    private final String message;
+    private final int status;
+
+    ErrorCode(final Long code, final String message, final int status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public Long getCode() {
+        return this.code;
+    }
+
+    public int getStatus() {
+        return this.status;
+    }
+}

--- a/server/src/main/java/backend/server/exception/ErrorResponse.java
+++ b/server/src/main/java/backend/server/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package backend.server.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private String message;
+    private Long code;
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.code = code.getCode();
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+}

--- a/server/src/main/java/backend/server/exception/GlobalExceptionAdvisor.java
+++ b/server/src/main/java/backend/server/exception/GlobalExceptionAdvisor.java
@@ -1,0 +1,18 @@
+package backend.server.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionAdvisor {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+}


### PR DESCRIPTION
기존 예외처리 방식은 Controller나 Service 단에서 직접 예외 처리 메세지와 코드를 입력했으나
코드가 난잡해지고 좋은 가독성을 가져오는데 부적합하다고 판단하여 Enum 클래스로 예외 처리
메세지를 만들고 BussinessException을 처리하도록 CustomException을 각각 만들었다.
클래스의 수는 많아지겠지만 통일성 있고 깔끔하게 예외처리가 가능하도록 개선하였다.